### PR TITLE
patchとdeleteの実装

### DIFF
--- a/src/main/java/com/example/RestApiTraining/Controller.java
+++ b/src/main/java/com/example/RestApiTraining/Controller.java
@@ -1,5 +1,6 @@
 package com.example.RestApiTraining;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -42,5 +43,18 @@ public class Controller {
                 .build()
                 .toUri();
         return ResponseEntity.created(url).body("name successfully created");
+    }
+
+    @PatchMapping("/patch/{id}")
+    public ResponseEntity<Map<String, String>> patch(@PathVariable("id") int patchId, @RequestBody PatchForm form) {
+        Customer.put(patchId, form.getName());
+
+        return ResponseEntity.ok(Map.of("message", "name successfully updated"));
+    }
+
+    @DeleteMapping("/delete/{id}")
+    public ResponseEntity<String> delete(@PathVariable("id") int deleteId) {
+        Customer.remove(deleteId);
+        return new ResponseEntity<>("name successfully created", HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/RestApiTraining/PatchForm.java
+++ b/src/main/java/com/example/RestApiTraining/PatchForm.java
@@ -1,0 +1,13 @@
+package com.example.RestApiTraining;
+
+public class PatchForm {
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}


### PR DESCRIPTION
第7回講座課題のpatchとdeleteを実装しました。

patchの結果　id 1の田中さんを佐藤さんに変更しました。
![スクリーンショット (120)](https://user-images.githubusercontent.com/109859819/192298792-dfc223eb-b3bb-4f78-bfea-cecb5ef9fbe3.png)
![スクリーンショット (121)](https://user-images.githubusercontent.com/109859819/192298872-e84d1842-335e-4106-8bf4-0d42ed7dfc31.png)

deleteの結果　id 3の橋本さんを削除しました。
![スクリーンショット (124)](https://user-images.githubusercontent.com/109859819/192299867-a261494a-1eb2-4523-901e-dc4259d1ef45.png)
![スクリーンショット (125)](https://user-images.githubusercontent.com/109859819/192299239-b8e94b15-f626-4992-81d3-9c2cba02da84.png)
faf9.png)
